### PR TITLE
feat: add session tags with fzf-powered interactive editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd ~/Code/myapp && muxx
 - [Installation](#installation)
 - [Quick start](#quick-start)
 - [Commands](#commands)
+- [Tags](#tags)
 - [Config](#config)
 - [Shell completions](#shell-completions)
 - [Shell integration](#shell-integration)
@@ -113,8 +114,18 @@ muxx connect -c ~/Code/myapp --cmd "npm run dev"
 # Interactively pick a session with fzf (requires fzf in PATH)
 muxx pick
 
-# List all sessions (table view with windows, panes, last seen, CWD, startup)
+# List all sessions (table view with windows, panes, last seen, CWD, startup, tags)
 muxx list
+
+# Tag a session interactively — fzf multi-select over all known tags
+muxx tag edit myapp
+
+# Add tags explicitly
+muxx tag add myapp work python
+
+# Filter the session list or picker by tag
+muxx list --tag work
+muxx pick --tag work
 
 # Rename a session
 muxx rename myapp work
@@ -130,18 +141,19 @@ muxx current
 
 ## Commands
 
-| Command                                                                        | Alias | Description                                                     |
-| ------------------------------------------------------------------------------ | ----- | --------------------------------------------------------------- |
-| `muxx`                                                                         |       | Connect to a session in the current directory                   |
-| `muxx connect [session] [-c <dir>] [--name <n>] [--no-attach] [--cmd "<cmd>"]` | `c`   | Attach to an existing session or create one from a directory    |
-| `muxx attach <name>`                                                           | `a`   | Attach or switch to an existing session by name (never creates) |
-| `muxx pick`                                                                    | `p`   | Interactively pick a session to attach to using fzf             |
-| `muxx list [--json]`                                                           | `ls`  | List sessions with windows, panes, last seen, CWD, and startup  |
-| `muxx kill <name> [--force]`                                                   | `k`   | Kill a session by name                                          |
-| `muxx rename <from> <to>`                                                      | `rn`  | Rename an existing session                                      |
-| `muxx current`                                                                 | `cur` | Print the current session name                                  |
-| `muxx doctor`                                                                  | `doc` | Validate environment and config; report any issues              |
-| `muxx completion <bash\|zsh\|fish>`                                            |       | Print shell completion script                                   |
+| Command                                                                        | Alias | Description                                                          |
+| ------------------------------------------------------------------------------ | ----- | -------------------------------------------------------------------- |
+| `muxx`                                                                         |       | Connect to a session in the current directory                        |
+| `muxx connect [session] [-c <dir>] [--name <n>] [--no-attach] [--cmd "<cmd>"]` | `c`   | Attach to an existing session or create one from a directory         |
+| `muxx attach <name>`                                                           | `a`   | Attach or switch to an existing session by name (never creates)      |
+| `muxx pick [--tag <tag>]...`                                                   | `p`   | Interactively pick a session using fzf; tags shown and searchable    |
+| `muxx list [--json] [--tag <tag>]...`                                          | `ls`  | List sessions with windows, panes, last seen, CWD, startup, and tags |
+| `muxx tag <subcommand>`                                                        | `t`   | Add, remove, or list tags on sessions                                |
+| `muxx kill <name> [--force]`                                                   | `k`   | Kill a session by name                                               |
+| `muxx rename <from> <to>`                                                      | `rn`  | Rename an existing session (tags are migrated automatically)         |
+| `muxx current`                                                                 | `cur` | Print the current session name                                       |
+| `muxx doctor`                                                                  | `doc` | Validate environment and config; report any issues                   |
+| `muxx completion <bash\|zsh\|fish>`                                            |       | Print shell completion script                                        |
 
 ### `connect` vs `attach`
 
@@ -167,18 +179,77 @@ muxx a work               # alias
 muxx pick
 muxx p                    # alias
 
+# Pick only sessions tagged "work"
+muxx pick --tag work
+
 # Create a session without attaching (useful in scripts)
 muxx connect -c ~/Code/myapp --no-attach
 
-# List sessions as JSON (includes name, windows, attached, created, last_attached)
+# List sessions as JSON (includes name, windows, attached, created, last_attached, tags)
 muxx list --json
+
+# List only sessions tagged "work"
+muxx list --tag work
 
 # Force-kill the current session
 muxx kill mysession --force
 
-# Rename a session
+# Rename a session (tags are migrated automatically)
 muxx rename old-name new-name
 muxx rn old-name new-name   # alias
+```
+
+---
+
+## Tags
+
+Sessions can have any number of free-form tags (e.g. `work`, `python`, `personal`). Tags persist by session name — they survive kills and recreations, and are migrated automatically on rename.
+
+Tags are stored in `~/.config/muxx/tags.json` (overridable via `MUXX_TAGS_PATH`).
+
+### Managing tags
+
+```sh
+# Interactive toggle — fzf multi-select over all known tags
+# Currently applied tags appear first, marked with *
+muxx tag edit myapp
+muxx t e myapp              # alias
+
+# Add tags — opens fzf picker when no tags given
+muxx tag add myapp work python
+muxx tag add myapp          # interactive: pick from known tags not already applied
+
+# Remove tags — opens fzf picker when no tags given
+muxx tag rm myapp python
+muxx tag rm myapp           # interactive: pick from session's current tags
+
+# Remove all tags
+muxx tag clear myapp
+
+# List tags
+muxx tag ls                 # all tagged sessions
+muxx tag ls myapp           # one session
+muxx tag list myapp         # alias for ls
+```
+
+### Filtering by tag
+
+`--tag` uses AND semantics — a session must have **all** listed tags to appear.
+
+```sh
+muxx list --tag work
+muxx list --tag work --tag python   # sessions that have BOTH tags
+muxx pick --tag work                # fzf picker pre-filtered to "work" sessions
+```
+
+### Tags in the fzf picker
+
+`muxx pick` shows tags alongside session names in fzf, so you can fuzzy-search across both:
+
+```
+> my-project        python, work
+  personal-site     personal
+  scratch
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,7 +47,10 @@ Each file exposes a single `pub fn run()` function:
 |---|---|
 | `connect.rs` | Creates or reattaches to a session; resolves alias → directory → session name |
 | `attach.rs` | Attaches or switches to an existing session; never creates |
-| `list.rs` | Lists sessions as a table or `--json` |
+| `list.rs` | Lists sessions as a table or `--json`; supports `--tag` filtering and shows TAGS column |
+| `pick.rs` | fzf-based session picker; shows tags alongside names; supports `--tag` pre-filter |
+| `tag.rs` | Manages session tags: `add`, `rm`, `edit` (fzf toggle), `clear`, `ls` |
+| `rename.rs` | Renames a session; migrates its tags to the new name |
 | `kill.rs` | Kills a session; guards against killing the current one without `--force` |
 | `current.rs` | Prints the current session name; errors if not in tmux |
 | `doctor.rs` | Validates tmux availability, config JSON, project directories, and duplicate session names |
@@ -60,18 +63,23 @@ Utilities shared across command modules:
 | File | Responsibility |
 |---|---|
 | `config.rs` | Loads `~/.config/muxx/config.json`; resolves project aliases to `ProjectConfig` |
+| `tags.rs` | Loads and saves `~/.config/muxx/tags.json`; `TagsStore` maps session names to sorted tag lists |
 | `env.rs` | `is_inside_tmux()`, home expansion, directory resolution |
 | `tmux.rs` | Wraps tmux CLI calls; `run()` captures stdout, `run_interactive()` inherits stdio for attach/switch |
 | `session_name.rs` | Sanitizes arbitrary strings into valid tmux session names (lowercase, hyphens) |
+| `state.rs` | Persists the last-attached session name to `~/.local/share/muxx/last_session` |
 | `output.rs` | ANSI-colored print helpers (`success`, `info`, `error`, `hint`) |
+| `fuzzy.rs` | Two-pass substring/subsequence matching used for fuzzy session lookup |
 
 ## Pure vs shell-dependent
 
 **Unit-testable without tmux** — these functions only do string manipulation or JSON parsing and are tested with in-source `#[cfg(test)]` modules:
 
 - `core/config.rs` — JSON parsing and struct logic
+- `core/tags.rs` — tag store mutations, serialization round-trips
 - `core/env.rs` — path expansion
 - `core/session_name.rs` — string sanitization
+- `core/fuzzy.rs` — substring/subsequence matching
 
 **Requires a running tmux server** — these are exercised by integration tests in `tests/`:
 
@@ -83,10 +91,14 @@ Utilities shared across command modules:
 ```
 tests/
   connect.rs       — integration tests for muxx connect
-  list.rs          — integration tests for muxx list
+  list.rs          — integration tests for muxx list (including --tag filtering)
+  tag.rs           — integration tests for muxx tag (add/rm/clear/ls/edit)
   kill.rs          — integration tests for muxx kill
+  rename.rs        — integration tests for muxx rename
+  attach.rs        — integration tests for muxx attach
   current.rs       — integration tests for muxx current
   doctor.rs        — integration tests for muxx doctor (config, dirs, duplicates)
+  pick.rs          — smoke tests for muxx pick (fzf requires a tty; full flow not tested in CI)
   completion.rs    — smoke tests for completion output
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,9 @@ pub enum Commands {
         /// Output as JSON
         #[arg(long)]
         json: bool,
+        /// Filter sessions by tag (repeatable: --tag work --tag rust)
+        #[arg(long = "tag", action = clap::ArgAction::Append)]
+        tags: Vec<String>,
     },
 
     /// Kill a session by name
@@ -95,6 +98,16 @@ pub enum Commands {
         /// Select without attaching (for testing)
         #[arg(long = "no-attach")]
         no_attach: bool,
+        /// Only show sessions matching all given tags
+        #[arg(long = "tag", action = clap::ArgAction::Append)]
+        tags: Vec<String>,
+    },
+
+    /// Add, remove, or list tags on sessions
+    #[command(alias = "t")]
+    Tag {
+        #[command(subcommand)]
+        action: TagAction,
     },
 
     /// Print the current session name
@@ -110,6 +123,52 @@ pub enum Commands {
         /// Shell to generate completions for
         #[arg(value_enum)]
         shell: Shell,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum TagAction {
+    /// Add tags to a session; opens fzf picker when no tags are given
+    Add {
+        /// Session name to tag
+        #[arg(add = ArgValueCompleter::new(complete_sessions))]
+        session: String,
+        /// Tags to add — omit to pick interactively with fzf
+        #[arg(num_args = 0..)]
+        tags: Vec<String>,
+    },
+
+    /// Remove tags from a session; opens fzf picker when no tags are given
+    Rm {
+        /// Session name
+        #[arg(add = ArgValueCompleter::new(complete_sessions))]
+        session: String,
+        /// Tags to remove — omit to pick interactively with fzf
+        #[arg(num_args = 0..)]
+        tags: Vec<String>,
+    },
+
+    /// Interactively toggle tags on a session (fzf multi-select)
+    #[command(alias = "e")]
+    Edit {
+        /// Session name
+        #[arg(add = ArgValueCompleter::new(complete_sessions))]
+        session: String,
+    },
+
+    /// Remove all tags from a session
+    Clear {
+        /// Session name
+        #[arg(add = ArgValueCompleter::new(complete_sessions))]
+        session: String,
+    },
+
+    /// List tags for a session, or all sessions if no name given
+    #[command(alias = "list")]
+    Ls {
+        /// Session name (omit to list all tagged sessions)
+        #[arg(add = ArgValueCompleter::new(complete_sessions))]
+        session: Option<String>,
     },
 }
 
@@ -134,10 +193,11 @@ pub fn run() -> anyhow::Result<()> {
             no_attach,
             cmd.as_deref(),
         ),
-        Some(Commands::List { json }) => commands::list::run(json),
+        Some(Commands::List { json, tags }) => commands::list::run(json, &tags),
         Some(Commands::Kill { name, force }) => commands::kill::run(&name, force),
         Some(Commands::Rename { from, to }) => commands::rename::run(&from, &to),
-        Some(Commands::Pick { no_attach }) => commands::pick::run(no_attach),
+        Some(Commands::Pick { no_attach, tags }) => commands::pick::run(no_attach, &tags),
+        Some(Commands::Tag { action }) => commands::tag::run(action),
         Some(Commands::Current) => commands::current::run(),
         Some(Commands::Doctor) => commands::doctor::run(),
         Some(Commands::Completion { shell }) => {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -48,7 +48,10 @@ pub fn run(json: bool, filter_tags: &[String]) -> Result<()> {
 
     // Apply tag filter: keep sessions that have ALL of the requested tags.
     if !filter_tags.is_empty() {
-        let normalized: Vec<String> = filter_tags.iter().map(|t| t.trim().to_lowercase()).collect();
+        let normalized: Vec<String> = filter_tags
+            .iter()
+            .map(|t| t.trim().to_lowercase())
+            .collect();
         sessions.retain(|s| {
             let session_tags = tags_store.get_tags(&s.name);
             normalized.iter().all(|ft| session_tags.contains(ft))
@@ -131,7 +134,21 @@ pub fn run(json: bool, filter_tags: &[String]) -> Result<()> {
         "NAME", "WINS", "PANES", "LAST SEEN", "STATE", "CWD", "STARTUP",
     );
     // Separator
-    let total = name_w + 2 + wins_w + 2 + panes_w + 2 + age_w + 2 + state_w + 2 + cwd_w + 2 + startup_w + 2 + tags_w;
+    let total = name_w
+        + 2
+        + wins_w
+        + 2
+        + panes_w
+        + 2
+        + age_w
+        + 2
+        + state_w
+        + 2
+        + cwd_w
+        + 2
+        + startup_w
+        + 2
+        + tags_w;
     println!("\x1b[2m{}\x1b[0m", "─".repeat(total));
 
     // Rows

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,11 +1,13 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
+use serde::Serialize;
 
 use crate::core::{
     config::load_config,
     output::{error, hint},
-    tmux::{get_panes_per_session, get_session_paths, has_tmux, list_sessions},
+    tags::load_tags,
+    tmux::{get_panes_per_session, get_session_paths, has_tmux, list_sessions, TmuxSession},
 };
 
 fn format_age(ts: u64) -> String {
@@ -28,16 +30,40 @@ fn format_age(ts: u64) -> String {
     }
 }
 
-pub fn run(json: bool) -> Result<()> {
+#[derive(Serialize)]
+struct SessionWithTags<'a> {
+    #[serde(flatten)]
+    session: &'a TmuxSession,
+    tags: Vec<String>,
+}
+
+pub fn run(json: bool, filter_tags: &[String]) -> Result<()> {
     if !has_tmux() {
         error("tmux not found in PATH");
         std::process::exit(1);
     }
 
-    let sessions = list_sessions();
+    let mut sessions = list_sessions();
+    let tags_store = load_tags();
+
+    // Apply tag filter: keep sessions that have ALL of the requested tags.
+    if !filter_tags.is_empty() {
+        let normalized: Vec<String> = filter_tags.iter().map(|t| t.trim().to_lowercase()).collect();
+        sessions.retain(|s| {
+            let session_tags = tags_store.get_tags(&s.name);
+            normalized.iter().all(|ft| session_tags.contains(ft))
+        });
+    }
 
     if json {
-        println!("{}", serde_json::to_string_pretty(&sessions)?);
+        let with_tags: Vec<SessionWithTags> = sessions
+            .iter()
+            .map(|s| SessionWithTags {
+                session: s,
+                tags: tags_store.get_tags(&s.name),
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&with_tags)?);
         return Ok(());
     }
 
@@ -59,12 +85,14 @@ pub fn run(json: bool) -> Result<()> {
         attached: bool,
         cwd: String,
         startup: bool,
+        tags: String,
     }
 
     let rows: Vec<Row> = sessions
         .iter()
         .map(|s| {
             let proj = config.projects.get(&s.name);
+            let tag_list = tags_store.get_tags(&s.name);
             Row {
                 name: s.name.clone(),
                 wins: format!("{}w", s.windows),
@@ -76,6 +104,11 @@ pub fn run(json: bool) -> Result<()> {
                     .or_else(|| paths_map.get(&s.name).cloned())
                     .unwrap_or_else(|| "-".to_string()),
                 startup: proj.and_then(|p| p.startup.as_ref()).is_some(),
+                tags: if tag_list.is_empty() {
+                    "-".to_string()
+                } else {
+                    tag_list.join(", ")
+                },
             }
         })
         .collect();
@@ -86,16 +119,19 @@ pub fn run(json: bool) -> Result<()> {
     let panes_w = rows.iter().map(|r| r.panes.len()).max().unwrap_or(0).max(5);
     let age_w = rows.iter().map(|r| r.age.len()).max().unwrap_or(0).max(9);
     let cwd_w = rows.iter().map(|r| r.cwd.len()).max().unwrap_or(0).max(3);
+    let tags_w = rows.iter().map(|r| r.tags.len()).max().unwrap_or(0).max(4);
     // "attached" / "detached" are always 8 chars — header "STATE" is 5.
     let state_w = 8_usize;
+    // "STARTUP" header is 7 chars; symbol value is 1 char — pad explicitly.
+    let startup_w = 7_usize;
 
     // Header
     println!(
-        "\x1b[2m{:<name_w$}  {:<wins_w$}  {:<panes_w$}  {:<age_w$}  {:<state_w$}  {:<cwd_w$}  STARTUP\x1b[0m",
-        "NAME", "WINS", "PANES", "LAST SEEN", "STATE", "CWD",
+        "\x1b[2m{:<name_w$}  {:<wins_w$}  {:<panes_w$}  {:<age_w$}  {:<state_w$}  {:<cwd_w$}  {:<startup_w$}  TAGS\x1b[0m",
+        "NAME", "WINS", "PANES", "LAST SEEN", "STATE", "CWD", "STARTUP",
     );
     // Separator
-    let total = name_w + 2 + wins_w + 2 + panes_w + 2 + age_w + 2 + state_w + 2 + cwd_w + 2 + 7;
+    let total = name_w + 2 + wins_w + 2 + panes_w + 2 + age_w + 2 + state_w + 2 + cwd_w + 2 + startup_w + 2 + tags_w;
     println!("\x1b[2m{}\x1b[0m", "─".repeat(total));
 
     // Rows
@@ -106,16 +142,18 @@ pub fn run(json: bool) -> Result<()> {
         } else {
             format!("\x1b[2m{state_plain}\x1b[0m")
         };
-        let startup = if r.startup {
+        let startup_sym = if r.startup {
             "\x1b[32m✓\x1b[0m"
         } else {
             "\x1b[2m-\x1b[0m"
         };
-        // state_colored has invisible ANSI bytes; pad manually using the plain width.
+        // state_colored and startup_sym have invisible ANSI bytes; pad manually using plain widths.
         let state_pad = " ".repeat(state_w.saturating_sub(state_plain.len()));
+        // startup symbol is always 1 visible char; pad to startup_w.
+        let startup_pad = " ".repeat(startup_w.saturating_sub(1));
         println!(
-            "{:<name_w$}  {:<wins_w$}  {:<panes_w$}  {:<age_w$}  {state_colored}{state_pad}  {:<cwd_w$}  {startup}",
-            r.name, r.wins, r.panes, r.age, r.cwd,
+            "{:<name_w$}  {:<wins_w$}  {:<panes_w$}  {:<age_w$}  {state_colored}{state_pad}  {:<cwd_w$}  {startup_sym}{startup_pad}  {tags}",
+            r.name, r.wins, r.panes, r.age, r.cwd, tags = r.tags,
         );
     }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod kill;
 pub mod list;
 pub mod pick;
 pub mod rename;
+pub mod tag;

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -7,25 +7,45 @@ use crate::core::{
     env::is_inside_tmux,
     output::{error, hint},
     state,
+    tags::load_tags,
     tmux::{attach_session, has_tmux, list_sessions, switch_client},
 };
 
-pub fn run(no_attach: bool) -> Result<()> {
+pub fn run(no_attach: bool, filter_tags: &[String]) -> Result<()> {
     if !has_tmux() {
         error("tmux not found in PATH");
         std::process::exit(1);
     }
 
-    let sessions = list_sessions();
+    let mut sessions = list_sessions();
+    let tags_store = load_tags();
+
+    // Apply tag filter: keep sessions that have ALL of the requested tags.
+    if !filter_tags.is_empty() {
+        let normalized: Vec<String> = filter_tags.iter().map(|t| t.trim().to_lowercase()).collect();
+        sessions.retain(|s| {
+            let session_tags = tags_store.get_tags(&s.name);
+            normalized.iter().all(|ft| session_tags.contains(ft))
+        });
+    }
 
     if sessions.is_empty() {
         hint("no sessions");
         return Ok(());
     }
 
+    // Format lines as "session_name\ttag1, tag2" so fzf shows tags and they
+    // are fuzzy-searchable alongside the session name.
     let input: String = sessions
         .iter()
-        .map(|s| s.name.as_str())
+        .map(|s| {
+            let tags = tags_store.get_tags(&s.name);
+            if tags.is_empty() {
+                s.name.clone()
+            } else {
+                format!("{}\t{}", s.name, tags.join(", "))
+            }
+        })
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -53,7 +73,9 @@ pub fn run(no_attach: bool) -> Result<()> {
         return Ok(());
     }
 
-    let session_name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let raw = String::from_utf8_lossy(&output.stdout);
+    // Extract session name — it's the part before the tab (tags follow after \t).
+    let session_name = raw.split('\t').next().unwrap_or("").trim().to_string();
 
     if session_name.is_empty() || no_attach {
         return Ok(());

--- a/src/commands/pick.rs
+++ b/src/commands/pick.rs
@@ -22,7 +22,10 @@ pub fn run(no_attach: bool, filter_tags: &[String]) -> Result<()> {
 
     // Apply tag filter: keep sessions that have ALL of the requested tags.
     if !filter_tags.is_empty() {
-        let normalized: Vec<String> = filter_tags.iter().map(|t| t.trim().to_lowercase()).collect();
+        let normalized: Vec<String> = filter_tags
+            .iter()
+            .map(|t| t.trim().to_lowercase())
+            .collect();
         sessions.retain(|s| {
             let session_tags = tags_store.get_tags(&s.name);
             normalized.iter().all(|ft| session_tags.contains(ft))

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -32,6 +32,11 @@ pub fn run(from: &str, to: &str) -> Result<()> {
 
     state::update_last_session_if(from, &to);
 
+    // Migrate tags to the new session name (best-effort).
+    let mut tag_store = crate::core::tags::load_tags();
+    tag_store.rename_session(from, &to);
+    let _ = crate::core::tags::save_tags(&tag_store);
+
     success(&format!("renamed: {from} -> {to}"));
     Ok(())
 }

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -1,0 +1,231 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use anyhow::Result;
+
+use crate::cli::TagAction;
+use crate::core::{
+    output::{error, hint, success},
+    tags::{load_tags, save_tags},
+};
+
+/// Spawns fzf with multi-select and returns the chosen lines (stripped of whitespace).
+/// Returns an empty vec if the user cancels (Escape / Ctrl-C).
+fn fzf_multi_select(items: &[String], header: &str, prompt: &str) -> Result<Vec<String>> {
+    let input = items.join("\n");
+
+    let mut child = match Command::new("fzf")
+        .args([
+            "--multi",
+            "--header",
+            header,
+            "--prompt",
+            prompt,
+            "--layout=reverse",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            error("fzf not found in PATH — install it to use interactive tag selection");
+            std::process::exit(1);
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = stdin.write_all(input.as_bytes());
+    }
+
+    let output = child.wait_with_output()?;
+
+    if !output.status.success() {
+        // User cancelled
+        return Ok(vec![]);
+    }
+
+    let selected = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    Ok(selected)
+}
+
+pub fn run(action: TagAction) -> Result<()> {
+    match action {
+        TagAction::Add { session, tags } => {
+            let mut store = load_tags();
+
+            let to_add = if tags.is_empty() {
+                // Interactive: show known tags not already on this session.
+                let current = store.get_tags(&session);
+                let available: Vec<String> = store
+                    .all_known_tags()
+                    .into_iter()
+                    .filter(|t| !current.contains(t))
+                    .collect();
+
+                if available.is_empty() {
+                    hint(&format!(
+                        "no other known tags — use: muxx tag add {session} <tag>"
+                    ));
+                    return Ok(());
+                }
+
+                let selected = fzf_multi_select(
+                    &available,
+                    "TAB: select  ·  Enter: add tags  ·  Esc: cancel",
+                    "add tags> ",
+                )?;
+
+                if selected.is_empty() {
+                    return Ok(());
+                }
+                selected
+            } else {
+                tags
+            };
+
+            store.add_tags(&session, &to_add);
+            save_tags(&store)?;
+            let current = store.get_tags(&session);
+            success(&format!("tagged {}: {}", session, current.join(", ")));
+        }
+
+        TagAction::Rm { session, tags } => {
+            let mut store = load_tags();
+
+            let to_remove = if tags.is_empty() {
+                // Interactive: show current tags to pick from.
+                let current = store.get_tags(&session);
+
+                if current.is_empty() {
+                    hint(&format!("no tags on {session}"));
+                    return Ok(());
+                }
+
+                let selected = fzf_multi_select(
+                    &current,
+                    "TAB: select  ·  Enter: remove tags  ·  Esc: cancel",
+                    "remove tags> ",
+                )?;
+
+                if selected.is_empty() {
+                    return Ok(());
+                }
+                selected
+            } else {
+                tags
+            };
+
+            store.remove_tags(&session, &to_remove);
+            save_tags(&store)?;
+            let remaining = store.get_tags(&session);
+            if remaining.is_empty() {
+                success(&format!("removed tags from {session}"));
+            } else {
+                success(&format!(
+                    "tags remaining on {}: {}",
+                    session,
+                    remaining.join(", ")
+                ));
+            }
+        }
+
+        TagAction::Edit { session } => {
+            let mut store = load_tags();
+            let current = store.get_tags(&session);
+            let all_known = store.all_known_tags();
+
+            if all_known.is_empty() {
+                hint(&format!(
+                    "no tags known yet — use: muxx tag add {session} <tag>"
+                ));
+                return Ok(());
+            }
+
+            // Build display list: current tags first (marked with "* "),
+            // then remaining known tags (marked with "  ").
+            // The user selects the desired final set — whatever is selected = new tags.
+            let mut items: Vec<String> = current
+                .iter()
+                .map(|t| format!("* {t}"))
+                .chain(
+                    all_known
+                        .iter()
+                        .filter(|t| !current.contains(t))
+                        .map(|t| format!("  {t}")),
+                )
+                .collect();
+
+            // Deduplicate in case current and all_known overlap unexpectedly.
+            items.dedup();
+
+            let selected = fzf_multi_select(
+                &items,
+                "TAB: toggle  ·  Enter: save  ·  Esc: cancel  ·  (* = currently tagged)",
+                "tags> ",
+            )?;
+
+            if selected.is_empty() {
+                // User cancelled — leave tags unchanged.
+                return Ok(());
+            }
+
+            // Strip the "* " / "  " visual prefix to get plain tag names.
+            let new_tags: Vec<String> = selected
+                .iter()
+                .map(|line| line.trim_start_matches(['*', ' ']).trim().to_string())
+                .filter(|t| !t.is_empty())
+                .collect();
+
+            store.clear_tags(&session);
+            store.add_tags(&session, &new_tags);
+            save_tags(&store)?;
+
+            let saved = store.get_tags(&session);
+            if saved.is_empty() {
+                success(&format!("cleared all tags from {session}"));
+            } else {
+                success(&format!("tags for {}: {}", session, saved.join(", ")));
+            }
+        }
+
+        TagAction::Clear { session } => {
+            let mut store = load_tags();
+            store.clear_tags(&session);
+            save_tags(&store)?;
+            success(&format!("cleared all tags from {session}"));
+        }
+
+        TagAction::Ls { session } => {
+            let store = load_tags();
+            match session {
+                Some(name) => {
+                    let tags = store.get_tags(&name);
+                    if tags.is_empty() {
+                        hint(&format!("no tags for {name}"));
+                    } else {
+                        println!("{}: {}", name, tags.join(", "));
+                    }
+                }
+                None => {
+                    if store.tags.is_empty() {
+                        hint("no tags");
+                        return Ok(());
+                    }
+                    let mut entries: Vec<_> = store.tags.iter().collect();
+                    entries.sort_by_key(|(k, _)| k.as_str());
+                    for (name, tags) in entries {
+                        println!("{}: {}", name, tags.join(", "));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,4 +4,5 @@ pub mod fuzzy;
 pub mod output;
 pub mod session_name;
 pub mod state;
+pub mod tags;
 pub mod tmux;

--- a/src/core/tags.rs
+++ b/src/core/tags.rs
@@ -1,0 +1,288 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct TagsStore {
+    #[serde(default)]
+    pub tags: HashMap<String, Vec<String>>,
+}
+
+impl TagsStore {
+    pub fn get_tags(&self, session: &str) -> Vec<String> {
+        self.tags.get(session).cloned().unwrap_or_default()
+    }
+
+    pub fn add_tags(&mut self, session: &str, tags: &[String]) {
+        let entry = self.tags.entry(session.to_string()).or_default();
+        for tag in tags {
+            let normalized = tag.trim().to_lowercase();
+            if !normalized.is_empty() {
+                entry.push(normalized);
+            }
+        }
+        entry.sort();
+        entry.dedup();
+        if entry.is_empty() {
+            self.tags.remove(session);
+        }
+    }
+
+    pub fn remove_tags(&mut self, session: &str, tags: &[String]) {
+        if let Some(entry) = self.tags.get_mut(session) {
+            let to_remove: Vec<String> = tags.iter().map(|t| t.trim().to_lowercase()).collect();
+            entry.retain(|t| !to_remove.contains(t));
+            if entry.is_empty() {
+                self.tags.remove(session);
+            }
+        }
+    }
+
+    pub fn clear_tags(&mut self, session: &str) {
+        self.tags.remove(session);
+    }
+
+    pub fn rename_session(&mut self, old: &str, new: &str) {
+        if let Some(tags) = self.tags.remove(old) {
+            self.tags.insert(new.to_string(), tags);
+        }
+    }
+
+    /// Returns a sorted, deduplicated list of every tag used across all sessions.
+    pub fn all_known_tags(&self) -> Vec<String> {
+        let mut all: Vec<String> = self
+            .tags
+            .values()
+            .flat_map(|v| v.iter().cloned())
+            .collect();
+        all.sort();
+        all.dedup();
+        all
+    }
+}
+
+pub fn tags_path() -> PathBuf {
+    if let Ok(p) = std::env::var("MUXX_TAGS_PATH") {
+        return PathBuf::from(p);
+    }
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("~/.config"))
+        .join("muxx")
+        .join("tags.json")
+}
+
+pub fn load_tags() -> TagsStore {
+    load_tags_from(&tags_path())
+}
+
+fn load_tags_from(path: &std::path::Path) -> TagsStore {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => {
+            if raw.trim().is_empty() {
+                return TagsStore::default();
+            }
+            match serde_json::from_str::<TagsStore>(&raw) {
+                Ok(store) => store,
+                Err(e) => {
+                    crate::core::output::error(&format!(
+                        "invalid JSON in {}: {}",
+                        path.display(),
+                        e
+                    ));
+                    std::process::exit(1);
+                }
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => TagsStore::default(),
+        Err(e) => {
+            crate::core::output::error(&format!(
+                "failed to read tags {}: {}",
+                path.display(),
+                e
+            ));
+            std::process::exit(1);
+        }
+    }
+}
+
+fn save_tags_to(store: &TagsStore, path: &std::path::Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(store)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+pub fn save_tags(store: &TagsStore) -> Result<()> {
+    save_tags_to(store, &tags_path())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_tags_deduplicates() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string(), "work".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["work"]);
+    }
+
+    #[test]
+    fn add_tags_sorts() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["z".to_string(), "a".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["a", "z"]);
+    }
+
+    #[test]
+    fn add_tags_normalises_case() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["Work".to_string(), "PYTHON".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["python", "work"]);
+    }
+
+    #[test]
+    fn add_tags_trims_whitespace() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["  work  ".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["work"]);
+    }
+
+    #[test]
+    fn add_tags_ignores_empty() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["".to_string(), "  ".to_string()]);
+        assert!(store.get_tags("proj").is_empty());
+        assert!(!store.tags.contains_key("proj"));
+    }
+
+    #[test]
+    fn add_tags_accumulates_across_calls() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string()]);
+        store.add_tags("proj", &["python".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["python", "work"]);
+    }
+
+    #[test]
+    fn remove_tags_partial() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string(), "python".to_string()]);
+        store.remove_tags("proj", &["python".to_string()]);
+        assert_eq!(store.get_tags("proj"), vec!["work"]);
+    }
+
+    #[test]
+    fn remove_tags_cleans_up_empty_key() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string()]);
+        store.remove_tags("proj", &["work".to_string()]);
+        assert!(!store.tags.contains_key("proj"));
+    }
+
+    #[test]
+    fn remove_tags_noop_for_unknown_session() {
+        let mut store = TagsStore::default();
+        store.remove_tags("nonexistent", &["work".to_string()]);
+        assert!(store.tags.is_empty());
+    }
+
+    #[test]
+    fn remove_tags_normalises_case() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string()]);
+        store.remove_tags("proj", &["WORK".to_string()]);
+        assert!(store.get_tags("proj").is_empty());
+    }
+
+    #[test]
+    fn clear_tags_removes_key() {
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string()]);
+        store.clear_tags("proj");
+        assert!(!store.tags.contains_key("proj"));
+    }
+
+    #[test]
+    fn clear_tags_noop_for_unknown_session() {
+        let mut store = TagsStore::default();
+        store.clear_tags("nonexistent");
+        assert!(store.tags.is_empty());
+    }
+
+    #[test]
+    fn rename_session_migrates_tags() {
+        let mut store = TagsStore::default();
+        store.add_tags("old", &["work".to_string()]);
+        store.rename_session("old", "new");
+        assert!(store.get_tags("old").is_empty());
+        assert_eq!(store.get_tags("new"), vec!["work"]);
+    }
+
+    #[test]
+    fn rename_session_noop_when_no_tags() {
+        let mut store = TagsStore::default();
+        store.rename_session("old", "new");
+        assert!(store.tags.is_empty());
+    }
+
+    #[test]
+    fn get_tags_returns_empty_for_unknown_session() {
+        let store = TagsStore::default();
+        assert!(store.get_tags("unknown").is_empty());
+    }
+
+    #[test]
+    fn all_known_tags_returns_union() {
+        let mut store = TagsStore::default();
+        store.add_tags("a", &["work".to_string(), "rust".to_string()]);
+        store.add_tags("b", &["work".to_string(), "personal".to_string()]);
+        let all = store.all_known_tags();
+        assert_eq!(all, vec!["personal", "rust", "work"]);
+    }
+
+    #[test]
+    fn all_known_tags_empty_store() {
+        let store = TagsStore::default();
+        assert!(store.all_known_tags().is_empty());
+    }
+
+    #[test]
+    fn load_tags_returns_default_when_missing() {
+        let store =
+            load_tags_from(std::path::Path::new("/tmp/muxx-test-nonexistent-tags-file.json"));
+        assert!(store.tags.is_empty());
+    }
+
+    #[test]
+    fn roundtrip_save_and_load() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let path = f.path().to_path_buf();
+
+        let mut store = TagsStore::default();
+        store.add_tags("proj", &["work".to_string(), "rust".to_string()]);
+
+        save_tags_to(&store, &path).unwrap();
+        let loaded = load_tags_from(&path);
+        assert_eq!(loaded.get_tags("proj"), vec!["rust", "work"]);
+
+        drop(f);
+    }
+
+    #[test]
+    fn roundtrip_empty_store() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let path = f.path().to_path_buf();
+
+        let store = TagsStore::default();
+        save_tags_to(&store, &path).unwrap();
+        let loaded = load_tags_from(&path);
+        assert!(loaded.tags.is_empty());
+
+        drop(f);
+    }
+}

--- a/src/core/tags.rs
+++ b/src/core/tags.rs
@@ -52,11 +52,7 @@ impl TagsStore {
 
     /// Returns a sorted, deduplicated list of every tag used across all sessions.
     pub fn all_known_tags(&self) -> Vec<String> {
-        let mut all: Vec<String> = self
-            .tags
-            .values()
-            .flat_map(|v| v.iter().cloned())
-            .collect();
+        let mut all: Vec<String> = self.tags.values().flat_map(|v| v.iter().cloned()).collect();
         all.sort();
         all.dedup();
         all
@@ -97,11 +93,7 @@ fn load_tags_from(path: &std::path::Path) -> TagsStore {
         }
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => TagsStore::default(),
         Err(e) => {
-            crate::core::output::error(&format!(
-                "failed to read tags {}: {}",
-                path.display(),
-                e
-            ));
+            crate::core::output::error(&format!("failed to read tags {}: {}", path.display(), e));
             std::process::exit(1);
         }
     }
@@ -253,8 +245,9 @@ mod tests {
 
     #[test]
     fn load_tags_returns_default_when_missing() {
-        let store =
-            load_tags_from(std::path::Path::new("/tmp/muxx-test-nonexistent-tags-file.json"));
+        let store = load_tags_from(std::path::Path::new(
+            "/tmp/muxx-test-nonexistent-tags-file.json",
+        ));
         assert!(store.tags.is_empty());
     }
 

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -202,8 +202,14 @@ fn list_tag_filter_shows_only_matching() {
     kill(untagged);
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    assert!(stdout.contains(tagged), "tagged session should appear: {stdout}");
-    assert!(!stdout.contains(untagged), "untagged session should be excluded: {stdout}");
+    assert!(
+        stdout.contains(tagged),
+        "tagged session should appear: {stdout}"
+    );
+    assert!(
+        !stdout.contains(untagged),
+        "untagged session should be excluded: {stdout}"
+    );
 }
 
 #[test]
@@ -251,8 +257,14 @@ fn list_multiple_tag_filters_and_semantics() {
     kill(one_only);
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    assert!(stdout.contains(both), "session with both tags should appear: {stdout}");
-    assert!(!stdout.contains(one_only), "session missing 'rust' should be excluded: {stdout}");
+    assert!(
+        stdout.contains(both),
+        "session with both tags should appear: {stdout}"
+    );
+    assert!(
+        !stdout.contains(one_only),
+        "session missing 'rust' should be excluded: {stdout}"
+    );
 }
 
 #[test]

--- a/tests/list.rs
+++ b/tests/list.rs
@@ -1,6 +1,17 @@
 use assert_cmd::Command;
 use predicates::str::contains;
 
+fn kill(session: &str) {
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+fn with_tags_file() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
 /// When there are no sessions (or tmux is not running), list returns successfully
 /// with either empty output or "no sessions". We can't guarantee tmux state in CI,
 /// so we test that the command exits 0 (list never fails for "no sessions").
@@ -153,4 +164,137 @@ fn list_without_json_does_not_crash_with_sessions() {
 
     // The text output should contain the session name
     result.stdout(contains(session));
+}
+
+#[test]
+fn list_tag_filter_shows_only_matching() {
+    let tagged = "muxx-test-list-filter-tagged";
+    let untagged = "muxx-test-list-filter-untagged";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", tagged])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", untagged])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", tagged, "work"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["list", "--tag", "work"])
+        .output()
+        .unwrap();
+
+    kill(tagged);
+    kill(untagged);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains(tagged), "tagged session should appear: {stdout}");
+    assert!(!stdout.contains(untagged), "untagged session should be excluded: {stdout}");
+}
+
+#[test]
+fn list_multiple_tag_filters_and_semantics() {
+    let both = "muxx-test-list-filter-both-tags";
+    let one_only = "muxx-test-list-filter-one-tag";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", both])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", one_only])
+        .assert()
+        .success();
+
+    // "both" gets two tags, "one_only" gets just one
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", both, "work", "rust"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", one_only, "work"])
+        .assert()
+        .success();
+
+    // Filter for both tags — only "both" should appear
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["list", "--tag", "work", "--tag", "rust"])
+        .output()
+        .unwrap();
+
+    kill(both);
+    kill(one_only);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains(both), "session with both tags should appear: {stdout}");
+    assert!(!stdout.contains(one_only), "session missing 'rust' should be excluded: {stdout}");
+}
+
+#[test]
+fn list_json_includes_tags_field() {
+    let session = "muxx-test-list-json-tags-field";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "work"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["list", "--json"])
+        .output()
+        .unwrap();
+
+    kill(session);
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let arr: serde_json::Value = serde_json::from_str(&stdout).expect("not valid JSON");
+    let arr = arr.as_array().expect("should be array");
+
+    let entry = arr
+        .iter()
+        .find(|s| s["name"].as_str() == Some(session))
+        .expect("session should appear in JSON output");
+
+    let tags = entry["tags"].as_array().expect("tags should be an array");
+    assert!(
+        tags.iter().any(|t| t.as_str() == Some("work")),
+        "tags array should contain 'work', got: {tags:?}"
+    );
 }

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -1,0 +1,268 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+use std::process::Stdio;
+
+fn kill(session: &str) {
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn with_tags_file() -> tempfile::NamedTempFile {
+    tempfile::NamedTempFile::new().unwrap()
+}
+
+#[test]
+fn tag_add_and_ls_shows_tag() {
+    let session = "muxx-test-tag-add-ls";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "work"])
+        .assert()
+        .success()
+        .stdout(contains("work"));
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", session])
+        .assert()
+        .success()
+        .stdout(contains("work"));
+
+    kill(session);
+}
+
+#[test]
+fn tag_add_multiple_tags() {
+    let session = "muxx-test-tag-multi";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "work", "python"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", session])
+        .output()
+        .unwrap();
+
+    kill(session);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains("work"), "expected 'work' in: {stdout}");
+    assert!(stdout.contains("python"), "expected 'python' in: {stdout}");
+}
+
+#[test]
+fn tag_rm_removes_specific_tag() {
+    let session = "muxx-test-tag-rm";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "work", "python"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "rm", session, "python"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", session])
+        .output()
+        .unwrap();
+
+    kill(session);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains("work"), "expected 'work' to remain: {stdout}");
+    assert!(!stdout.contains("python"), "expected 'python' removed: {stdout}");
+}
+
+#[test]
+fn tag_clear_removes_all() {
+    let session = "muxx-test-tag-clear";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "work", "python"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "clear", session])
+        .assert()
+        .success()
+        .stdout(contains("cleared"));
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", session])
+        .assert()
+        .success()
+        .stdout(contains("no tags"));
+
+    kill(session);
+}
+
+#[test]
+fn tag_ls_all_shows_multiple_sessions() {
+    let a = "muxx-test-tag-ls-all-a";
+    let b = "muxx-test-tag-ls-all-b";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", a])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", b])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", a, "work"])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", b, "personal"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls"])
+        .output()
+        .unwrap();
+
+    kill(a);
+    kill(b);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains(a), "expected session a in output: {stdout}");
+    assert!(stdout.contains(b), "expected session b in output: {stdout}");
+    assert!(stdout.contains("work"), "expected 'work' tag: {stdout}");
+    assert!(stdout.contains("personal"), "expected 'personal' tag: {stdout}");
+}
+
+#[test]
+fn tag_ls_unknown_session_shows_hint() {
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", "muxx-no-such-session-xyz"])
+        .assert()
+        .success()
+        .stdout(contains("no tags"));
+}
+
+#[test]
+fn tag_alias_t_works() {
+    let session = "muxx-test-tag-alias-t";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["t", "add", session, "alias-test"])
+        .assert()
+        .success();
+
+    kill(session);
+}
+
+#[test]
+fn tag_add_normalises_case() {
+    let session = "muxx-test-tag-normalise";
+    let tags_file = with_tags_file();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "add", session, "WORK", "Python"])
+        .assert()
+        .success();
+
+    let output = Command::cargo_bin("muxx")
+        .unwrap()
+        .env("MUXX_TAGS_PATH", tags_file.path())
+        .args(["tag", "ls", session])
+        .output()
+        .unwrap();
+
+    kill(session);
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    assert!(stdout.contains("work"), "tag should be lowercased: {stdout}");
+    assert!(stdout.contains("python"), "tag should be lowercased: {stdout}");
+    assert!(!stdout.contains("WORK"), "should not contain uppercase: {stdout}");
+}

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -110,8 +110,14 @@ fn tag_rm_removes_specific_tag() {
     kill(session);
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    assert!(stdout.contains("work"), "expected 'work' to remain: {stdout}");
-    assert!(!stdout.contains("python"), "expected 'python' removed: {stdout}");
+    assert!(
+        stdout.contains("work"),
+        "expected 'work' to remain: {stdout}"
+    );
+    assert!(
+        !stdout.contains("python"),
+        "expected 'python' removed: {stdout}"
+    );
 }
 
 #[test]
@@ -197,7 +203,10 @@ fn tag_ls_all_shows_multiple_sessions() {
     assert!(stdout.contains(a), "expected session a in output: {stdout}");
     assert!(stdout.contains(b), "expected session b in output: {stdout}");
     assert!(stdout.contains("work"), "expected 'work' tag: {stdout}");
-    assert!(stdout.contains("personal"), "expected 'personal' tag: {stdout}");
+    assert!(
+        stdout.contains("personal"),
+        "expected 'personal' tag: {stdout}"
+    );
 }
 
 #[test]
@@ -262,7 +271,16 @@ fn tag_add_normalises_case() {
     kill(session);
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    assert!(stdout.contains("work"), "tag should be lowercased: {stdout}");
-    assert!(stdout.contains("python"), "tag should be lowercased: {stdout}");
-    assert!(!stdout.contains("WORK"), "should not contain uppercase: {stdout}");
+    assert!(
+        stdout.contains("work"),
+        "tag should be lowercased: {stdout}"
+    );
+    assert!(
+        stdout.contains("python"),
+        "tag should be lowercased: {stdout}"
+    );
+    assert!(
+        !stdout.contains("WORK"),
+        "should not contain uppercase: {stdout}"
+    );
 }


### PR DESCRIPTION
## Summary

Adds a tagging system for tmux sessions. Tags are free-form strings (e.g. \`work\`, \`python\`, \`personal\`) that persist by session name across kills and recreations. They can be used to filter the session list and the fzf picker, and are migrated automatically on rename.

## What changed

**New: \`muxx tag\` subcommand** (alias \`t\`)
- \`tag edit <session>\` — fzf multi-select over all known tags; currently applied tags appear first marked with \`*\`; selected set replaces existing tags
- \`tag add <session> [tags...]\` — adds tags; opens fzf picker when no tags given
- \`tag rm <session> [tags...]\` — removes tags; opens fzf picker when no tags given
- \`tag clear <session>\` — removes all tags
- \`tag ls [session]\` — lists tags for one session or all tagged sessions

**Updated: \`muxx list\`**
- New TAGS column in the table output
- \`--tag <tag>\` filter (repeatable; AND semantics — session must have all listed tags)
- JSON output now includes a \`tags\` field on each session object

**Updated: \`muxx pick\`**
- Tags are shown alongside session names in fzf (\`session-name  tag1, tag2\`) and are fuzzy-searchable
- \`--tag <tag>\` filter pre-narrows the list before fzf opens

**Updated: \`muxx rename\`**
- Tags are migrated to the new session name automatically (best-effort)

**Storage:** \`~/.config/muxx/tags.json\` — overridable via \`MUXX_TAGS_PATH\`

## How to test

```sh
# Tag a session interactively
muxx tag edit my-project

# Or add explicitly
muxx tag add my-project work python

# Check the list column and filter
muxx list
muxx list --tag work
muxx list --tag work --tag python   # AND filter

# fzf picker with tags visible and searchable
muxx pick
muxx pick --tag work

# Rename — tags follow
muxx rename my-project new-name
muxx tag ls new-name  # should show original tags

# Remove interactively
muxx tag rm new-name  # opens fzf over current tags
```

## Risks / Notes

- Tags are stored independently of the tmux server — no tmux API changes
- \`save_tags\` failures in \`rename\` are best-effort (silent), matching the existing pattern for \`state::update_last_session_if\`
- The \`tag edit\` fzf UX requires fzf in PATH (same requirement as \`muxx pick\`)
- No breaking changes to existing commands; \`tags\` is an additive field in JSON output

🤖 Generated with [Claude Code](https://claude.com/claude-code)