### PR TITLE
feat: add muxx init for interactive project onboarding

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -177,6 +177,13 @@ pub enum Commands {
         action: ConfigAction,
     },
 
+    /// Interactively register the current project and optionally create a session
+    Init {
+        /// Register without creating a session
+        #[arg(long = "no-attach")]
+        no_attach: bool,
+    },
+
     /// Export tags and notes to a TOML file
     Export {
         /// Output file path (omit to print to stdout)
@@ -303,6 +310,7 @@ pub fn run() -> anyhow::Result<()> {
         }) => commands::new::run(&path, name.as_deref(), cmd.as_deref(), no_attach),
         Some(Commands::Version { verbose }) => commands::version::run(verbose),
         Some(Commands::Config { action }) => commands::config::run(action),
+        Some(Commands::Init { no_attach }) => commands::init::run(no_attach),
         Some(Commands::Export { path }) => commands::export::run(path.as_deref()),
         Some(Commands::Import { path, merge }) => commands::import::run(&path, merge),
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,102 @@
+use std::io::{self, Write};
+
+use anyhow::{bail, Result};
+
+use crate::core::{
+    config::{config_path, load_config, save_config, ProjectConfig},
+    output::{hint, info, success, warn},
+    session_name::sanitize_session_name,
+    tags::{load_tags, save_tags},
+};
+
+pub fn run(no_attach: bool) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let cwd_str = cwd.to_string_lossy().into_owned();
+    let default_name = sanitize_session_name(&cwd_str);
+
+    if default_name.is_empty() {
+        bail!("cannot derive a project name from the current directory");
+    }
+
+    let name_input = prompt("Project name", Some(&default_name))?;
+    let name = sanitize_session_name(if name_input.is_empty() {
+        &default_name
+    } else {
+        &name_input
+    });
+    if name.is_empty() {
+        bail!("project name sanitizes to an empty string");
+    }
+
+    let startup_raw = prompt("Startup command (optional)", None)?;
+    let startup = if startup_raw.is_empty() {
+        None
+    } else {
+        Some(startup_raw)
+    };
+
+    let tags_raw = prompt("Tags (comma-separated, optional)", None)?;
+    let tags: Vec<String> = tags_raw
+        .split(',')
+        .map(|t| t.trim().to_lowercase())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    let create_now = prompt_bool("Create session now?", true)?;
+
+    let mut config = load_config();
+    if config.projects.contains_key(&name) {
+        warn(&format!(
+            "project \"{name}\" already exists in config — overwriting"
+        ));
+    }
+
+    config.projects.insert(
+        name.clone(),
+        ProjectConfig {
+            cwd: cwd_str,
+            startup,
+        },
+    );
+    save_config(&config)?;
+    success(&format!("config written: {}", config_path().display()));
+
+    if !tags.is_empty() {
+        let mut store = load_tags();
+        store.add_tags(&name, &tags);
+        save_tags(&store)?;
+        info(&format!("tags: {}", tags.join(", ")));
+    }
+
+    if create_now {
+        crate::commands::connect::run(Some(&name), None, None, no_attach, None)?;
+    } else {
+        hint(&format!("run `muxx {name}` to start your session"));
+    }
+
+    Ok(())
+}
+
+fn prompt(label: &str, default: Option<&str>) -> Result<String> {
+    match default {
+        Some(d) => print!("{label} [{d}]: "),
+        None => print!("{label}: "),
+    }
+    io::stdout().flush()?;
+    let mut buf = String::new();
+    io::stdin().read_line(&mut buf)?;
+    Ok(buf.trim().to_string())
+}
+
+fn prompt_bool(label: &str, default: bool) -> Result<bool> {
+    let indicator = if default { "[Y/n]" } else { "[y/N]" };
+    print!("{label} {indicator}: ");
+    io::stdout().flush()?;
+    let mut buf = String::new();
+    io::stdin().read_line(&mut buf)?;
+    let t = buf.trim().to_lowercase();
+    if t.is_empty() {
+        return Ok(default);
+    }
+    Ok(t == "y" || t == "yes")
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod doctor;
 pub mod export;
 pub mod gc;
 pub mod import;
+pub mod init;
 pub mod kill;
 pub mod last;
 pub mod list;

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -186,4 +186,109 @@ cwd = "/c"
         assert!(resolve_project(&cfg, "MyApp").is_none());
         assert!(resolve_project(&cfg, "myapp").is_some());
     }
+
+    #[test]
+    fn save_config_to_creates_file() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        let path = f.path().to_path_buf();
+
+        let mut cfg = MuxxConfig::default();
+        cfg.projects.insert(
+            "myapp".to_string(),
+            ProjectConfig {
+                cwd: "/tmp/myapp".to_string(),
+                startup: None,
+            },
+        );
+
+        save_config_to(&cfg, &path).unwrap();
+        assert!(path.exists());
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("myapp"));
+        assert!(raw.contains("/tmp/myapp"));
+    }
+
+    #[test]
+    fn save_config_omits_startup_when_none() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+
+        let mut cfg = MuxxConfig::default();
+        cfg.projects.insert(
+            "proj".to_string(),
+            ProjectConfig {
+                cwd: "/tmp/proj".to_string(),
+                startup: None,
+            },
+        );
+
+        save_config_to(&cfg, f.path()).unwrap();
+        let raw = std::fs::read_to_string(f.path()).unwrap();
+        assert!(
+            !raw.contains("startup"),
+            "startup key should not appear when value is None; got:\n{raw}"
+        );
+    }
+
+    #[test]
+    fn save_config_includes_startup_when_set() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+
+        let mut cfg = MuxxConfig::default();
+        cfg.projects.insert(
+            "proj".to_string(),
+            ProjectConfig {
+                cwd: "/tmp/proj".to_string(),
+                startup: Some("npm run dev".to_string()),
+            },
+        );
+
+        save_config_to(&cfg, f.path()).unwrap();
+        let raw = std::fs::read_to_string(f.path()).unwrap();
+        assert!(raw.contains("npm run dev"));
+    }
+
+    #[test]
+    fn save_config_roundtrip() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+
+        let mut cfg = MuxxConfig::default();
+        cfg.projects.insert(
+            "alpha".to_string(),
+            ProjectConfig {
+                cwd: "/tmp/alpha".to_string(),
+                startup: Some("make run".to_string()),
+            },
+        );
+        cfg.projects.insert(
+            "beta".to_string(),
+            ProjectConfig {
+                cwd: "/tmp/beta".to_string(),
+                startup: None,
+            },
+        );
+
+        save_config_to(&cfg, f.path()).unwrap();
+        let loaded = load_config_from(f.path());
+
+        let alpha = resolve_project(&loaded, "alpha").unwrap();
+        assert_eq!(alpha.cwd, "/tmp/alpha");
+        assert_eq!(alpha.startup.as_deref(), Some("make run"));
+
+        let beta = resolve_project(&loaded, "beta").unwrap();
+        assert_eq!(beta.cwd, "/tmp/beta");
+        assert!(beta.startup.is_none());
+    }
+
+    #[test]
+    fn save_config_creates_parent_directories() {
+        let base = tempfile::TempDir::new().unwrap();
+        let nested = base.path().join("a").join("b").join("config.toml");
+
+        let cfg = MuxxConfig::default();
+        save_config_to(&cfg, &nested).unwrap();
+        assert!(
+            nested.exists(),
+            "parent dirs should be created automatically"
+        );
+    }
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -1,15 +1,16 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ProjectConfig {
     pub cwd: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub startup: Option<String>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct MuxxConfig {
     #[serde(default)]
     pub projects: HashMap<String, ProjectConfig>,
@@ -46,6 +47,19 @@ fn load_config_from(path: &std::path::Path) -> MuxxConfig {
             std::process::exit(1);
         }
     }
+}
+
+pub fn save_config(config: &MuxxConfig) -> anyhow::Result<()> {
+    save_config_to(config, &config_path())
+}
+
+pub fn save_config_to(config: &MuxxConfig, path: &std::path::Path) -> anyhow::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let toml = toml::to_string_pretty(config)?;
+    std::fs::write(path, toml)?;
+    Ok(())
 }
 
 pub fn resolve_project<'a>(config: &'a MuxxConfig, key: &str) -> Option<&'a ProjectConfig> {

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,0 +1,348 @@
+use assert_cmd::Command;
+use predicates::str::contains;
+
+/// Return a `muxx` command with isolated config, tags, and notes stores.
+fn isolated(config: &std::path::Path, tags: &std::path::Path) -> assert_cmd::Command {
+    let mut cmd = Command::cargo_bin("muxx").unwrap();
+    cmd.env("MUXX_CONFIG_PATH", config)
+        .env("MUXX_TAGS_PATH", tags);
+    cmd
+}
+
+/// Simulate `muxx init --no-attach` feeding the four prompt answers via stdin.
+fn run_init(
+    dir: &std::path::Path,
+    config: &std::path::Path,
+    tags: &std::path::Path,
+    stdin: &str,
+) -> std::process::Output {
+    isolated(config, tags)
+        .current_dir(dir)
+        .args(["init", "--no-attach"])
+        .write_stdin(stdin)
+        .output()
+        .unwrap()
+}
+
+// ── config write tests ──────────────────────────────────────────────────────
+
+#[test]
+fn init_writes_project_to_config() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(dir.path(), config.path(), tags.path(), "myapp\n\n\nn\n");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    assert!(
+        raw.contains("[projects.myapp]"),
+        "config should contain the project"
+    );
+    assert!(
+        raw.contains(dir.path().to_str().unwrap()),
+        "config should contain the cwd"
+    );
+}
+
+#[test]
+fn init_writes_startup_command() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        "startupapp\nnpm run dev\n\nn\n",
+    );
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    assert!(
+        raw.contains("npm run dev"),
+        "config should contain startup command"
+    );
+}
+
+#[test]
+fn init_omits_startup_when_empty() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(dir.path(), config.path(), tags.path(), "plainproj\n\n\nn\n");
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    assert!(
+        !raw.contains("startup"),
+        "config should not have startup key when input was empty; got:\n{raw}"
+    );
+}
+
+#[test]
+fn init_writes_cwd_as_current_directory() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(dir.path(), config.path(), tags.path(), "cwdproj\n\n\nn\n");
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    // The path may be canonicalized; check that the temp dir path appears.
+    let dir_str = dir.path().to_str().unwrap();
+    assert!(
+        raw.contains(dir_str),
+        "config cwd should be the working directory; config:\n{raw}"
+    );
+}
+
+#[test]
+fn init_default_name_from_cwd_basename() {
+    let base = std::env::temp_dir().join("muxx-init-default-name-test");
+    std::fs::create_dir_all(&base).unwrap();
+
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    // Empty first line → accept default derived from basename.
+    let out = run_init(&base, config.path(), tags.path(), "\n\n\nn\n");
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    assert!(
+        raw.contains("muxx-init-default-name-test"),
+        "config should use the directory basename as project name; config:\n{raw}"
+    );
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[test]
+fn init_overwrites_existing_project() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    // First init
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        "overwrite-me\nold cmd\n\nn\n",
+    );
+    assert!(out.status.success());
+
+    // Second init — different startup command, same project name
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        "overwrite-me\nnew cmd\n\nn\n",
+    );
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(config.path()).unwrap();
+    assert!(
+        raw.contains("new cmd"),
+        "config should reflect the new startup command"
+    );
+    assert!(
+        !raw.contains("old cmd"),
+        "old startup command should be gone after overwrite"
+    );
+}
+
+#[test]
+fn init_prints_config_written_message() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    isolated(config.path(), tags.path())
+        .current_dir(dir.path())
+        .args(["init", "--no-attach"])
+        .write_stdin("printmsg\n\n\nn\n")
+        .assert()
+        .success()
+        .stdout(contains("config written"));
+}
+
+// ── tags tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn init_writes_tags_to_store() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        "taggedproj\n\nwork,nextjs\nn\n",
+    );
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(tags.path()).unwrap();
+    assert!(raw.contains("work"), "tags store should contain 'work'");
+    assert!(raw.contains("nextjs"), "tags store should contain 'nextjs'");
+}
+
+#[test]
+fn init_normalises_tags_to_lowercase() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        "lcproj\n\nWORK,Rust\nn\n",
+    );
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(tags.path()).unwrap();
+    assert!(raw.contains("work"), "tags should be lowercased");
+    assert!(raw.contains("rust"), "tags should be lowercased");
+    assert!(!raw.contains("WORK"), "uppercase tag should not appear");
+}
+
+#[test]
+fn init_no_tags_leaves_tags_file_unchanged() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    // Pre-seed the tags file with existing data.
+    std::fs::write(tags.path(), "[tags]\nother = [\"personal\"]\n").unwrap();
+
+    let out = run_init(dir.path(), config.path(), tags.path(), "notagproj\n\n\nn\n");
+    assert!(out.status.success());
+
+    let raw = std::fs::read_to_string(tags.path()).unwrap();
+    assert!(
+        raw.contains("other"),
+        "pre-existing tags should be untouched when no tags entered"
+    );
+    assert!(
+        !raw.contains("notagproj"),
+        "project with no tags should not appear in tags store"
+    );
+}
+
+#[test]
+fn init_prints_tags_in_output() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    isolated(config.path(), tags.path())
+        .current_dir(dir.path())
+        .args(["init", "--no-attach"])
+        .write_stdin("tagoutput\n\nrust,personal\nn\n")
+        .assert()
+        .success()
+        .stdout(contains("rust"))
+        .stdout(contains("personal"));
+}
+
+// ── session creation tests ──────────────────────────────────────────────────
+
+#[test]
+fn init_skips_session_when_answered_no() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let session = "muxx-init-test-no-session";
+
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        &format!("{session}\n\n\nn\n"),
+    );
+    assert!(out.status.success());
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("muxx"),
+        "should print hint to run muxx; stdout: {stdout}"
+    );
+
+    let session_exists = std::process::Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    assert!(
+        !session_exists,
+        "no tmux session should be created when user answers 'n'"
+    );
+}
+
+#[test]
+fn init_creates_session_when_answered_yes() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    let session = "muxx-init-test-yes-session";
+
+    let out = run_init(
+        dir.path(),
+        config.path(),
+        tags.path(),
+        &format!("{session}\n\n\ny\n"),
+    );
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let session_exists = std::process::Command::new("tmux")
+        .args(["has-session", "-t", session])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .status();
+
+    assert!(
+        session_exists,
+        "tmux session '{session}' should exist after init with 'y'"
+    );
+}
+
+#[test]
+fn init_prints_hint_when_session_not_created() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let config = tempfile::NamedTempFile::new().unwrap();
+    let tags = tempfile::NamedTempFile::new().unwrap();
+
+    isolated(config.path(), tags.path())
+        .current_dir(dir.path())
+        .args(["init", "--no-attach"])
+        .write_stdin("hintproj\n\n\nn\n")
+        .assert()
+        .success()
+        .stdout(contains("hintproj"));
+}


### PR DESCRIPTION
## Summary

Adds `muxx init`, an interactive command that walks the user through registering the current directory as a named project and optionally creating a session immediately. This turns muxx from a utility you configure by hand into an onboarding experience.

## What changed

**`core/config.rs`**
- Added `Serialize` + `skip_serializing_if` to `ProjectConfig` and `MuxxConfig` so configs can be written back to disk.
- Added `save_config` / `save_config_to` public functions.

**`commands/init.rs`** (new)
- Four-prompt interactive flow: project name (default = cwd basename), startup command, comma-separated tags, create session now?
- Writes the project entry to `~/.config/muxx/config.toml`.
- Writes tags to the tags store keyed to the session name.
- If user answers yes, calls `connect::run` with the new alias so the config entry (cwd + startup) is used immediately.
- `--no-attach` flag for test/scripting use.

**`cli.rs` / `commands/mod.rs`**
- Registered the `Init` subcommand and dispatch arm.

## How to test

```sh
cd ~/Code/myapp
muxx init
# Project name [myapp]: myapp
# Startup command (optional): npm run dev
# Tags (comma-separated, optional): work,nextjs
# Create session now? [Y/n]: y
```

After that:
- `~/.config/muxx/config.toml` has a `[projects.myapp]` entry.
- `muxx tag ls myapp` shows `nextjs, work`.
- `muxx ls` shows the new session.

## Risks / Notes

- Overwrites an existing config entry with the same name without a hard confirmation (emits a warning). This is intentional — `muxx init` is meant to be re-runnable to update startup commands.
- Config write-back does not preserve comments or field ordering in a hand-edited `config.toml` (TOML round-trip limitation).

## Tests

- 5 unit tests for `save_config_to` (creates file, omits/includes startup, roundtrip, creates parent dirs).
- 14 integration tests covering config writes, tag handling, session creation (yes/no), default name derivation, and overwrite behaviour. All run against isolated temp files via `MUXX_CONFIG_PATH` / `MUXX_TAGS_PATH` env vars.