### PR TITLE
Sync tmux-resurrect snapshot after session mutations (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ cd ~/Code/myapp && muxx
 - [Tags](#tags)
 - [Notes](#notes)
 - [Config](#config)
+- [tmux-resurrect / tmux-continuum](#tmux-resurrect--tmux-continuum)
 - [Export & Import](#export--import)
 - [Shell completions](#shell-completions)
 - [Shell integration](#shell-integration)
@@ -431,6 +432,30 @@ muxx config edit
 muxx config path
 cat "$(muxx config path)"
 ```
+
+---
+
+## tmux-resurrect / tmux-continuum
+
+If you use [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) (optionally with [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum)), muxx keeps their saved snapshot in sync with reality.
+
+Previously, killing a session with `muxx kill` left it in resurrect's saved snapshot, so it would come back at the next restore (a tmux server restart with continuum, or a manual `prefix + Ctrl-r`). muxx now re-runs resurrect's own `save.sh` after any session mutation — `kill`, `new`/`connect` (on creation), `rename`, and `gc` — so the snapshot always reflects the live session list.
+
+**How it works:**
+
+- Enabled automatically when tmux-resurrect is detected. No setup required.
+- A re-save is silent on success and never fails your command; if the save script is found but errors, muxx prints a non-fatal warning.
+- muxx probes the usual install locations (`$TMUX_PLUGIN_MANAGER_PATH`, `~/.tmux/plugins`, `~/.config/tmux/plugins`). Run `muxx doctor` to confirm detection.
+
+Disable it or point at a non-standard install via config:
+
+```toml
+[resurrect]
+enabled = true                 # set false to turn the integration off
+save_script = "~/.tmux/plugins/tmux-resurrect/scripts/save.sh"  # optional override
+```
+
+The save script can also be overridden with the `MUXX_RESURRECT_SAVE_SCRIPT` environment variable (takes precedence over config).
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -75,7 +75,7 @@ Utilities shared across command modules:
 
 | File | Responsibility |
 |---|---|
-| `config.rs` | Loads `~/.config/muxx/config.toml`; resolves project aliases to `ProjectConfig` |
+| `config.rs` | Loads `~/.config/muxx/config.toml`; resolves project aliases to `ProjectConfig`; holds `ResurrectConfig` (resurrect integration toggle + save-script override) |
 | `tags.rs` | Loads and saves `~/.config/muxx/tags.toml`; `TagsStore` maps session names to sorted tag lists; `delete_tag` removes a tag globally across all sessions |
 | `notes.rs` | Loads and saves `~/.config/muxx/notes.toml`; `NotesStore` maps session names to a single string note |
 | `env.rs` | `is_inside_tmux()`, home expansion, directory resolution |
@@ -84,6 +84,7 @@ Utilities shared across command modules:
 | `state.rs` | Persists the last-attached session name to `~/.local/share/muxx/last_session` |
 | `output.rs` | ANSI-colored print helpers (`success`, `info`, `warn`, `error`, `hint`); color is gated by TTY detection, `NO_COLOR`, and the `--no-color` flag (`set_no_color`/`stdout_color`) |
 | `fuzzy.rs` | Two-pass substring/subsequence matching used for fuzzy session lookup |
+| `resurrect.rs` | Re-runs tmux-resurrect's `save.sh` after session mutations so its saved snapshot stays in sync (issue #60); locates the script via `MUXX_RESURRECT_SAVE_SCRIPT`, config override, or probed plugin paths |
 
 ## Pure vs shell-dependent
 

--- a/src/commands/connect.rs
+++ b/src/commands/connect.rs
@@ -4,6 +4,7 @@ use crate::core::{
     config::{load_config, resolve_project},
     env::{is_inside_tmux, resolve_dir},
     output::{info, success, warn},
+    resurrect,
     session_name::resolve_session_name,
     state,
     tmux::{
@@ -80,6 +81,7 @@ fn run_dir_based(
     }
 
     let existed = has_session(&session_name);
+    let mut created = false;
 
     if !existed {
         if !create_session(&session_name, &dir_str) {
@@ -89,6 +91,7 @@ fn run_dir_based(
             }
             info(&format!("reused: {session_name}"));
         } else {
+            created = true;
             success(&format!("created: {session_name}"));
             if let Some(cmd) = startup_cmd {
                 if !send_keys(&session_name, cmd) {
@@ -120,6 +123,11 @@ fn run_dir_based(
             }
         }
         info(&format!("reused: {session_name}"));
+    }
+
+    // Refresh resurrect's snapshot before attaching (attach hijacks the terminal).
+    if created {
+        resurrect::save_snapshot();
     }
 
     do_attach(&session_name, no_attach)

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -4,9 +4,10 @@ use std::path::Path;
 use anyhow::Result;
 
 use crate::core::{
-    config::{config_path, MuxxConfig},
+    config::{config_path, load_config, MuxxConfig},
     env::expand_home,
     output::{error, hint, success},
+    resurrect,
     session_name::sanitize_session_name,
     tmux::has_tmux,
 };
@@ -76,6 +77,22 @@ pub fn run() -> Result<()> {
                     }
                 }
             },
+        }
+    }
+
+    // --- Check 5: tmux-resurrect integration ---
+    let cfg = load_config();
+    if !cfg.resurrect.enabled {
+        hint("tmux-resurrect integration disabled in config");
+    } else if let Some(script) = resurrect::resolve_save_script() {
+        success(&format!("tmux-resurrect detected: {}", script.display()));
+    } else {
+        hint("tmux-resurrect not detected — session save/restore sync inactive");
+    }
+    if let Some(s) = cfg.resurrect.save_script.as_deref() {
+        if !Path::new(&expand_home(s)).is_file() {
+            error(&format!("resurrect save_script not found: {s}"));
+            issues += 1;
         }
     }
 

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -3,6 +3,7 @@ use anyhow::{bail, Result};
 use crate::core::{
     notes::{load_notes, save_notes},
     output::{hint, success},
+    resurrect,
     tags::{load_tags, save_tags},
     tmux::{has_tmux, list_sessions},
 };
@@ -22,22 +23,25 @@ pub fn run() -> Result<()> {
 
     if dead_tag_sessions.is_empty() && dead_note_sessions.is_empty() {
         hint("nothing to clean up");
-        return Ok(());
-    }
+    } else {
+        if !dead_tag_sessions.is_empty() {
+            save_tags(&tags_store)?;
+            for s in &dead_tag_sessions {
+                success(&format!("removed tags for dead session: {s}"));
+            }
+        }
 
-    if !dead_tag_sessions.is_empty() {
-        save_tags(&tags_store)?;
-        for s in &dead_tag_sessions {
-            success(&format!("removed tags for dead session: {s}"));
+        if !dead_note_sessions.is_empty() {
+            save_notes(&notes_store)?;
+            for s in &dead_note_sessions {
+                success(&format!("removed note for dead session: {s}"));
+            }
         }
     }
 
-    if !dead_note_sessions.is_empty() {
-        save_notes(&notes_store)?;
-        for s in &dead_note_sessions {
-            success(&format!("removed note for dead session: {s}"));
-        }
-    }
+    // Reconcile resurrect's snapshot with live tmux — purges ghosts of sessions
+    // that died outside muxx, even when there was no muxx metadata to clean.
+    resurrect::save_snapshot();
 
     Ok(())
 }

--- a/src/commands/kill.rs
+++ b/src/commands/kill.rs
@@ -3,6 +3,7 @@ use anyhow::{bail, Result};
 use crate::core::{
     env::is_inside_tmux,
     output::success,
+    resurrect,
     tmux::{current_session, has_session, has_tmux, kill_session},
 };
 
@@ -26,6 +27,8 @@ pub fn run(name: &str, force: bool) -> Result<()> {
     if !kill_session(name) {
         bail!("failed to kill session: {name}");
     }
+
+    resurrect::save_snapshot();
 
     success(&format!("killed: {name}"));
     Ok(())

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -2,6 +2,7 @@ use anyhow::{bail, Result};
 
 use crate::core::{
     output::success,
+    resurrect,
     session_name::sanitize_session_name,
     state,
     tmux::{has_session, has_tmux, rename_session},
@@ -42,6 +43,8 @@ pub fn run(from: &str, to: &str) -> Result<()> {
     let mut notes_store = crate::core::notes::load_notes();
     notes_store.rename_session(from, &to);
     let _ = crate::core::notes::save_notes(&notes_store);
+
+    resurrect::save_snapshot();
 
     success(&format!("renamed: {from} -> {to}"));
     Ok(())

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -10,10 +10,35 @@ pub struct ProjectConfig {
     pub startup: Option<String>,
 }
 
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ResurrectConfig {
+    /// Whether muxx refreshes tmux-resurrect's snapshot after mutating sessions.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Explicit path to resurrect's `save.sh` for non-standard installs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub save_script: Option<String>,
+}
+
+impl Default for ResurrectConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            save_script: None,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct MuxxConfig {
     #[serde(default)]
     pub projects: HashMap<String, ProjectConfig>,
+    #[serde(default)]
+    pub resurrect: ResurrectConfig,
 }
 
 pub fn config_path() -> PathBuf {
@@ -277,6 +302,27 @@ cwd = "/c"
         let beta = resolve_project(&loaded, "beta").unwrap();
         assert_eq!(beta.cwd, "/tmp/beta");
         assert!(beta.startup.is_none());
+    }
+
+    #[test]
+    fn resurrect_defaults_to_enabled_when_section_absent() {
+        let cfg: MuxxConfig = toml::from_str("[projects.foo]\ncwd = \"/tmp/foo\"\n").unwrap();
+        assert!(cfg.resurrect.enabled);
+        assert!(cfg.resurrect.save_script.is_none());
+    }
+
+    #[test]
+    fn resurrect_can_be_disabled() {
+        let cfg: MuxxConfig = toml::from_str("[resurrect]\nenabled = false\n").unwrap();
+        assert!(!cfg.resurrect.enabled);
+    }
+
+    #[test]
+    fn resurrect_save_script_override_parses() {
+        let cfg: MuxxConfig =
+            toml::from_str("[resurrect]\nsave_script = \"/opt/save.sh\"\n").unwrap();
+        assert!(cfg.resurrect.enabled);
+        assert_eq!(cfg.resurrect.save_script.as_deref(), Some("/opt/save.sh"));
     }
 
     #[test]

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -3,6 +3,7 @@ pub mod env;
 pub mod fuzzy;
 pub mod notes;
 pub mod output;
+pub mod resurrect;
 pub mod session_name;
 pub mod state;
 pub mod tags;

--- a/src/core/resurrect.rs
+++ b/src/core/resurrect.rs
@@ -1,0 +1,132 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::core::{
+    config::{load_config, MuxxConfig},
+    env::expand_home,
+    output::warn,
+};
+
+/// Best-effort: refresh tmux-resurrect's snapshot from current live tmux state.
+///
+/// muxx mutates tmux (kill/new/rename/gc) but resurrect's saved snapshot is only
+/// rewritten on its own timer (via tmux-continuum) or a manual save. Without this,
+/// a killed session lingers in the snapshot and gets restored at the next restore
+/// event (see issue #60). Re-running resurrect's `save.sh` reconciles the snapshot
+/// immediately.
+///
+/// No-op (silent) when the integration is disabled in config or resurrect isn't
+/// installed. Non-fatal: failures only emit a warning — the caller's operation has
+/// already succeeded.
+pub fn save_snapshot() {
+    let config = load_config();
+    if !config.resurrect.enabled {
+        return;
+    }
+
+    let Some(script) = resolve_save_script_with(&config) else {
+        return;
+    };
+
+    // `quiet` suppresses resurrect's own "saved" message; capture output so it
+    // doesn't leak into muxx's stdout/stderr.
+    match Command::new(&script).arg("quiet").output() {
+        Ok(out) if out.status.success() => {}
+        Ok(out) => warn(&format!(
+            "tmux-resurrect save exited with status {} — snapshot may be stale",
+            out.status.code().unwrap_or(-1)
+        )),
+        Err(e) => warn(&format!("could not run tmux-resurrect save script: {e}")),
+    }
+}
+
+/// Resolve the resurrect `save.sh` path, or `None` if not found.
+/// Loads config itself; used by `muxx doctor`.
+pub(crate) fn resolve_save_script() -> Option<PathBuf> {
+    resolve_save_script_with(&load_config())
+}
+
+fn resolve_save_script_with(config: &MuxxConfig) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    // 1. Explicit env override (highest priority; also the integration-test seam).
+    if let Ok(p) = std::env::var("MUXX_RESURRECT_SAVE_SCRIPT") {
+        if !p.is_empty() {
+            candidates.push(PathBuf::from(expand_home(&p)));
+        }
+    }
+    // 2. Config override for non-standard installs.
+    if let Some(s) = config.resurrect.save_script.as_deref() {
+        candidates.push(PathBuf::from(expand_home(s)));
+    }
+    // 3. Probed default install locations.
+    candidates.extend(probe_default_paths());
+
+    first_existing(&candidates, |p| p.is_file())
+}
+
+/// Default tmux-resurrect install locations for `save.sh`.
+fn probe_default_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let suffix = "tmux-resurrect/scripts/save.sh";
+
+    if let Ok(tpm) = std::env::var("TMUX_PLUGIN_MANAGER_PATH") {
+        if !tpm.is_empty() {
+            paths.push(PathBuf::from(tpm).join(suffix));
+        }
+    }
+    if let Some(home) = dirs::home_dir() {
+        paths.push(home.join(".tmux/plugins").join(suffix));
+    }
+    let xdg_config = std::env::var("XDG_CONFIG_HOME")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".config")));
+    if let Some(cfg) = xdg_config {
+        paths.push(cfg.join("tmux/plugins").join(suffix));
+    }
+    paths
+}
+
+/// First candidate that satisfies `exists`, preserving priority order.
+fn first_existing(candidates: &[PathBuf], exists: impl Fn(&Path) -> bool) -> Option<PathBuf> {
+    candidates.iter().find(|p| exists(p)).cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_existing_returns_highest_priority_present() {
+        let env = PathBuf::from("/env/save.sh");
+        let cfg = PathBuf::from("/cfg/save.sh");
+        let probe = PathBuf::from("/probe/save.sh");
+        let candidates = vec![env.clone(), cfg.clone(), probe.clone()];
+
+        // env present -> env wins
+        assert_eq!(
+            first_existing(&candidates, |p| p == env || p == cfg),
+            Some(env.clone())
+        );
+        // env absent, config present -> config wins
+        assert_eq!(
+            first_existing(&candidates, |p| p == cfg || p == probe),
+            Some(cfg)
+        );
+        // only probe present -> probe wins
+        assert_eq!(first_existing(&candidates, |p| p == probe), Some(probe));
+    }
+
+    #[test]
+    fn first_existing_returns_none_when_nothing_present() {
+        let candidates = vec![PathBuf::from("/a"), PathBuf::from("/b")];
+        assert_eq!(first_existing(&candidates, |_| false), None);
+    }
+
+    #[test]
+    fn first_existing_empty_candidates_is_none() {
+        assert_eq!(first_existing(&[], |_| true), None);
+    }
+}

--- a/tests/resurrect.rs
+++ b/tests/resurrect.rs
@@ -1,0 +1,231 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+/// Build a temp dir containing an executable stub `save.sh` that records its
+/// invocation by creating an `invoked` marker file next to itself.
+///
+/// Returns the temp dir (kept alive by the caller), the script path to pass via
+/// `MUXX_RESURRECT_SAVE_SCRIPT`, and the marker path to assert on.
+fn stub_save_script() -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let dir = tempfile::TempDir::new().unwrap();
+    let script = dir.path().join("save.sh");
+    let marker = dir.path().join("invoked");
+
+    let mut f = std::fs::File::create(&script).unwrap();
+    // Record the invocation (and its args) so tests can assert it ran.
+    writeln!(f, "#!/bin/sh\necho \"$@\" > \"$(dirname \"$0\")/invoked\"").unwrap();
+    drop(f);
+
+    let mut perms = std::fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(&script, perms).unwrap();
+
+    (dir, script, marker)
+}
+
+fn kill_tmux(session: &str) {
+    let _ = std::process::Command::new("tmux")
+        .args(["kill-session", "-t", session])
+        .stderr(std::process::Stdio::null())
+        .status();
+}
+
+/// Regression test for issue #60: after `muxx kill`, muxx must refresh
+/// tmux-resurrect's snapshot so the killed session does not come back.
+#[test]
+fn kill_triggers_resurrect_save() {
+    let session = "muxx-test-resurrect-kill";
+    let (_dir, script, marker) = stub_save_script();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["kill", session])
+        .env_remove("TMUX")
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .assert()
+        .success();
+
+    assert!(
+        marker.exists(),
+        "resurrect save script should have been invoked after kill"
+    );
+}
+
+#[test]
+fn new_triggers_resurrect_save() {
+    let session = "muxx-test-resurrect-new";
+    let dir = tempfile::TempDir::new().unwrap();
+    let (_stub, script, marker) = stub_save_script();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args([
+            "new",
+            dir.path().to_str().unwrap(),
+            "--no-attach",
+            "--name",
+            session,
+        ])
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .assert()
+        .success();
+
+    kill_tmux(session);
+
+    assert!(
+        marker.exists(),
+        "resurrect save script should have been invoked after creating a session"
+    );
+}
+
+#[test]
+fn rename_triggers_resurrect_save() {
+    let from = "muxx-test-resurrect-rename-from";
+    let to = "muxx-test-resurrect-rename-to";
+    let (_stub, script, marker) = stub_save_script();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", from])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["session", "rename", from, to])
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .assert()
+        .success();
+
+    kill_tmux(from);
+    kill_tmux(to);
+
+    assert!(
+        marker.exists(),
+        "resurrect save script should have been invoked after rename"
+    );
+}
+
+#[test]
+fn gc_triggers_resurrect_save() {
+    let (_stub, script, marker) = stub_save_script();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["gc"])
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .assert()
+        .success();
+
+    assert!(
+        marker.exists(),
+        "resurrect save script should have been invoked after gc"
+    );
+}
+
+#[test]
+fn disabled_config_skips_resurrect_save() {
+    let session = "muxx-test-resurrect-disabled";
+    let (_stub, script, marker) = stub_save_script();
+
+    // Config that disables the integration.
+    let cfg = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(cfg.path(), "[resurrect]\nenabled = false\n").unwrap();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["kill", session])
+        .env_remove("TMUX")
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .env("MUXX_CONFIG_PATH", cfg.path())
+        .assert()
+        .success();
+
+    assert!(
+        !marker.exists(),
+        "resurrect save must be skipped when disabled in config"
+    );
+}
+
+#[test]
+fn kill_succeeds_when_resurrect_not_installed() {
+    let session = "muxx-test-resurrect-absent";
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["connect", "--no-attach", "--name", session])
+        .assert()
+        .success();
+
+    // Point at a path that does not exist, and an empty config dir so no real
+    // plugin is probed into. The kill must still succeed with no error output.
+    let empty_cfg = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(empty_cfg.path(), "").unwrap();
+
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args(["kill", session])
+        .env_remove("TMUX")
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", "/nonexistent/muxx/save.sh")
+        .env("MUXX_CONFIG_PATH", empty_cfg.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("killed"));
+}
+
+#[test]
+fn reused_session_does_not_trigger_resurrect_save() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let session = "muxx-test-resurrect-reused";
+    let (_stub, script, marker) = stub_save_script();
+
+    // First create (this would trigger a save, but we use a separate stub below).
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args([
+            "new",
+            dir.path().to_str().unwrap(),
+            "--no-attach",
+            "--name",
+            session,
+        ])
+        .assert()
+        .success();
+
+    // Reuse the existing session — must NOT trigger a save.
+    Command::cargo_bin("muxx")
+        .unwrap()
+        .args([
+            "new",
+            dir.path().to_str().unwrap(),
+            "--no-attach",
+            "--name",
+            session,
+        ])
+        .env("MUXX_RESURRECT_SAVE_SCRIPT", &script)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("reused"));
+
+    kill_tmux(session);
+
+    assert!(
+        !marker.exists(),
+        "reusing an existing session must not trigger a resurrect save"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #60. `muxx kill` removed a tmux session but left it in tmux-resurrect's saved snapshot, so the session was recreated at the next restore event — a tmux server restart with tmux-continuum, or a manual `prefix + Ctrl-r`. The session "came back from the dead."

Root cause: muxx mutated tmux (`kill`/`new`/`rename`) but never told resurrect, so its snapshot drifted out of sync with reality.

The fix re-runs resurrect's own `save.sh` after any session mutation, rewriting the snapshot from the live session list. One save also covers tmux-continuum, since it reuses resurrect's snapshot file.

## What changed

- **New `core/resurrect.rs`** — best-effort `save_snapshot()` plus script resolution. The save script is located via `MUXX_RESURRECT_SAVE_SCRIPT` → `[resurrect] save_script` config → probed plugin paths (`$TMUX_PLUGIN_MANAGER_PATH`, `~/.tmux/plugins`, `~/.config/tmux/plugins`).
- **Call sites** — re-save after `kill`, `new`/`connect` (only when a session is actually created, before the terminal-hijacking attach), `rename`, and `gc` (reconciles the snapshot with live tmux, purging ghosts of sessions killed outside muxx).
- **`[resurrect]` config** — `enabled` (default `true`, opt-out) and optional `save_script` override.
- **`muxx doctor`** — reports detection status, and errors on a configured-but-missing `save_script`.
- **Behavior** — automatic when resurrect is detected; silent on success; non-fatal warning if a detected save script errors; fully silent when resurrect isn't installed.
- **Docs** — README section + architecture-doc module entry.

## How to test

Automated (TDD, red→green):

```sh
cargo test --test resurrect   # 7 cases: kill/new/rename/gc trigger; disabled/not-installed/reused do not
cargo test                    # full suite: 277 passed / 0 failed
cargo clippy -- -D warnings   # clean
```

The integration tests use `MUXX_RESURRECT_SAVE_SCRIPT` pointing at a stub script that drops a marker file — no real plugin needed in CI.

Manual (on a machine with tmux-resurrect/continuum):

```sh
muxx new /tmp/ghost --no-attach
# prefix + Ctrl-s  (or wait for continuum)
muxx kill ghost
grep ghost ~/.local/share/tmux/resurrect/last   # gone
tmux kill-server && tmux                          # ghost does NOT return
muxx doctor                                       # shows "tmux-resurrect detected: <path>"
```

## Risks / Notes

- No behavior change for users without tmux-resurrect installed — detection is "save script exists," otherwise a silent no-op.
- `gc` does **not** kill tmux sessions (it only prunes muxx's own tags/notes); its re-save fires for the *reconcile-with-live-tmux* reason, so it now runs even on the "nothing to clean up" path (early-return restructured into an if/else).
- A configured-but-missing `save_script` is surfaced by `muxx doctor` rather than warned on every command.
- semver: binary crate, no public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)